### PR TITLE
Corrected to use relative file

### DIFF
--- a/nplusone/__init__.py
+++ b/nplusone/__init__.py
@@ -1,1 +1,1 @@
-from base import show_nplusones
+from .base import show_nplusones


### PR DESCRIPTION
Using as directed in readme does not work since django cannot find 'base'. Changing to '.base' resolved the issue.